### PR TITLE
Titres dégradés

### DIFF
--- a/code/UI.js
+++ b/code/UI.js
@@ -51,7 +51,6 @@ export const PageMain = styled.main`
 
 export const Title = styled.h1`
 	${({ colors }) =>
-		false &&
 		colors &&
 		css`
 			background: linear-gradient(to bottom left, ${colors[0]}, ${colors[1]});
@@ -61,7 +60,6 @@ export const Title = styled.h1`
 `
 export const ArticleStyle = styled.div`
 	${({ colors }) =>
-		false &&
 		colors &&
 		css`
 			h1 {


### PR DESCRIPTION
Une tentative de :art: style des titres sur les pages inspirée du logo.


![Capture d’écran du 2021-02-17 16-51-04](https://user-images.githubusercontent.com/1177762/108229704-57370000-7140-11eb-8b54-c1e90acf13a3.png)
